### PR TITLE
Persist username in search params

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
 		<nav class="navbar navbar-expand-lg navbar-light bg-light">
-			<a class="navbar-brand" href="#">Get Timeline</a>
+			<a class="navbar-brand" href="/">Get Timeline</a>
 		</nav>
 
 		<div class="container mb-5">

--- a/js/main.js
+++ b/js/main.js
@@ -58,16 +58,29 @@ function getEventType (type, payload) {
     return event
 }
 
+function addUsernameToSearchParams(username) {
+    const url = new URL(document.location.href)
+    const params = new URLSearchParams(url.search)
+    params.set('username', username)
+    window.history.pushState({}, "", decodeURIComponent(`${location.pathname}?${params}`))
+}
+
+function getTimeline(username) {
+    page = 1
+
+    addUsernameToSearchParams(username)
+
+    $('.items').html(`<h2 class="align-items-center timeline">@${username}'s Timeline</h2>`)
+    $('.load-more').removeClass('d-none')
+    getItems(username)
+}
 
 $('#get-timeline').click(e => {
     e.preventDefault()
 
     let username = $('#username').val().trim()
-    page = 1
-
-    $('.items').html(`<h2 class="align-items-center timeline">@${username}'s Timeline</h2>`)
-    $('.load-more').removeClass('d-none')
-    getItems(username)
+    
+    getTimeline(username)
 })
 
 $('#load-more').click((e) => {
@@ -84,3 +97,15 @@ async function fetchAsync (username, page = 1) {
     let data = await response.json()
     return data
 }
+
+function main() {
+    const params = new URLSearchParams(location.search)
+    const username = params.get('username')
+
+    if (username) {
+        $('#username').val(username)
+        getTimeline(username)
+    }
+}
+
+main()


### PR DESCRIPTION
I added the ability to persist the search query in the search params. This will make it possible to refresh the page and still see the timeline of the same user.

It's using the [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/url) and [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) APIs which are unsupported in Internet Explorer (they are supported in Edge and all other browsers). Assuming you'd want this functionality merged in at all, should I skip the code for IE users?