### PR TITLE
Filter `MemberEvent`s

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@ let page = 1
 
 function getItems (username) {
     fetchAsync(username, page)
+        .then(filterUselessEvents)
         .then(data => {
             $('.loader').css('display', 'none')
             $('.timeline').css('display', 'block')
@@ -56,6 +57,10 @@ function getEventType (type, payload) {
             event = ''
     }
     return event
+}
+
+function filterUselessEvents(events) {
+    return events.filter(element => element.type !== 'MemberEvent')
 }
 
 


### PR DESCRIPTION
[`MemberEvent`s](https://developer.github.com/v3/activity/events/types/#memberevent) are triggered when a user is added or removed as a collaborator, this can result in duplicate notifications such as seen here:

<img width="1485" alt="screenshot 2018-10-22 at 18 54 49" src="https://user-images.githubusercontent.com/876666/47306334-6cf99080-d62c-11e8-9c33-7c38512479e8.png">

There are two events for `Connected-Information-systems/diff-test-coverage`, because GitHub returns a `CreateEvent` for the repository being created and a `MemberEvent` for the user, I think this happens when a user creates a repository in an org (created repo + added themselves as a member of the repo).

I thought it might be best to just filter out the `MemberEvent`s as they're also not being shown on GitHub itself. Let me know what you think of this solution!